### PR TITLE
parsing fix for longitude >= 100

### DIFF
--- a/src/NMEA.jl
+++ b/src/NMEA.jl
@@ -667,8 +667,9 @@ function _dms_to_dd(dms::SubString, hemi::SubString)
         dms = dms[2:end]
     end
 
-    degrees = Base.parse(Float64, dms[1:2])
-    minutes = Base.parse(Float64, dms[3:end])
+    decimalindex = findfirst('.', dms)
+    degrees = Base.parse(Float64, dms[1:decimalindex-3])
+    minutes = Base.parse(Float64, dms[decimalindex-2:end])
     dec_degrees = degrees + (minutes / 60)
 
     if (hemi == "S" || hemi == "W")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,5 +35,7 @@ end
 
 
 example = NMEA.parse(raw"$GPGGA,134740.000,5540.3248,N,01231.2992,E,1,09,0.9,20.2,M,41.5,M,,0000*61")
-
 @test(example.latitude == 55.67208)
+
+example = NMEA.parse("\$GNGGA,033158.447,4532.5164,N,12258.1463,W,1,9,1.25,161.5,M,-19.6,M,,*7E")
+@test(example.longitude == -122.969105)


### PR DESCRIPTION
When longitude >= 100, there are 5 digits before the decimal and the existing parser breaks.